### PR TITLE
umqtt.robust: let reconnect() call the connect() method of the top class

### DIFF
--- a/umqtt.robust/umqtt/robust.py
+++ b/umqtt.robust/umqtt/robust.py
@@ -20,7 +20,7 @@ class MQTTClient(simple.MQTTClient):
         i = 0
         while 1:
             try:
-                return super().connect(False)
+                return self.connect(False)
             except OSError as e:
                 self.log(True, e)
                 i += 1


### PR DESCRIPTION
This allow overriding of the connect() method by a subclass.